### PR TITLE
Diskspace demo fixes

### DIFF
--- a/actions/diskspace_remediation.meta.yaml
+++ b/actions/diskspace_remediation.meta.yaml
@@ -18,7 +18,7 @@
     threshold:
       type: "integer"
       description: "threshold for check diskspace action. percentage"
-      default: "50"
+      default: 50
     check_name:
       type: "string"
       description: "Check name as passed from sensu"

--- a/actions/diskspace_remediation.meta.yaml
+++ b/actions/diskspace_remediation.meta.yaml
@@ -8,9 +8,11 @@
     hostname:
       type: "string"
       description: "Host to remediate disk space on"
+      required: true
     directory:
       type: "string"
       description: "Directory to prune if over the threshold"
+      required: true
     file_extension:
       type: "string"
       description: "file extension to be used during pruning"

--- a/actions/reset_diskspace_demo.meta.yaml
+++ b/actions/reset_diskspace_demo.meta.yaml
@@ -8,6 +8,7 @@
     hostname:
       type: "string"
       description: "Host to reset disk space demo on"
+      required: true
     skip_notify:
       immutable: true
       default:

--- a/actions/workflows/diskspace_remediation.yaml
+++ b/actions/workflows/diskspace_remediation.yaml
@@ -68,5 +68,5 @@ workflows:
         action: slack.post_message
         input:
           channel: "#demos"
-          message: "DemoBot has pruned <% $.directory %> on <% $.hostname %> due to a monitoring event.  ID: <% $.event_id %>\nhttp://st2demo004:8080/#/history/<% env().st2_execution_id %>/general"
+          message: "DemoBot has pruned <% $.directory %> on <% $.hostname %> due to a monitoring event.  ID: <% $.event_id %>\nhttps://st2demo004/#/history/<% env().st2_execution_id %>/general"
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: st2_demos
 name : st2_demos
 description : Demos workflows and rules
-version : 0.2.0
+version : 0.2.1
 author : st2_dev
 email : info@stackstorm.com


### PR DESCRIPTION
- Use integer, not string for default threshold
- Updated demo server URL
- Made hostname & directory params required for disk space remediation actions