### PR TITLE
Better target Sensu check

### DIFF
--- a/actions/chains/reset_diskspace_demo.yaml
+++ b/actions/chains/reset_diskspace_demo.yaml
@@ -21,7 +21,7 @@
       ref: "sensu.check_request"
       params:
         check: "diskspace"
-        subscribers: "linux"
+        subscribers: "demo-linux"
       on-success: "remove_stash"
     -
       name: "remove_stash"


### PR DESCRIPTION
When resetting the disk space it gets Sensu to run a disk check. The list of subscribers was too broad, and it was checking all systems. This narrows it down to just the systems used as part of the demo